### PR TITLE
Use yaml.safe_load rather than yaml.load

### DIFF
--- a/mapshader/services.py
+++ b/mapshader/services.py
@@ -284,7 +284,7 @@ def get_services(config_path=None, include_default=True, contains=None, sources=
     else:
         with open(config_path, 'r') as f:
             content = f.read()
-            config_obj = yaml.load(content)
+            config_obj = yaml.safe_load(content)
             source_objs = config_obj['sources']
 
         if include_default:


### PR DESCRIPTION
Since `pyyaml` 6.0, `yaml.load()` has required a second argument `Loader` that was previously optional.

The recommended approach is to use `yaml.safe_load()` instead. This has been in place since at least August 2017 so there is no problem supporting older versions of pyyaml with this change.