### PR TITLE
Multithreaded support for multiband multiple NetCDF files

### DIFF
--- a/mapshader/flask_app.py
+++ b/mapshader/flask_app.py
@@ -214,5 +214,4 @@ if __name__ == '__main__':
     if user_file:
         user_file = path.abspath(path.expanduser(user_file))
 
-    app = create_app(user_file, contains=service_grep).run(
-        host='0.0.0.0', debug=False, threaded=False, processes=4)
+    app = create_app(user_file, contains=service_grep).run(host='0.0.0.0', debug=debug)


### PR DESCRIPTION
Add multithreaded support for the recent addition of multiband multiple NetCDF file inputs.

This allows the flask server to be run in the default multithreaded mode rather than multiple processes instead.