### PR TITLE
Overviews

### DIFF
--- a/example_multiband/multiband_netcdf.yaml
+++ b/example_multiband/multiband_netcdf.yaml
@@ -26,6 +26,12 @@ sources:
       - name: reproject_raster
         args:
           epsg: 3857
+      - name: build_raster_overviews
+        args:
+          levels:
+            0: 256
+            1: 512
+            2: 1024
     service_types:
       - tile
 
@@ -51,6 +57,12 @@ sources:
       - name: reproject_raster
         args:
           epsg: 3857
+      - name: build_raster_overviews
+        args:
+          levels:
+            0: 256
+            1: 512
+            2: 1024
     service_types:
       - tile
 
@@ -76,5 +88,11 @@ sources:
       - name: reproject_raster
         args:
           epsg: 3857
+      - name: build_raster_overviews
+        args:
+          levels:
+            0: 256
+            1: 512
+            2: 1024
     service_types:
       - tile

--- a/example_multiband/run_multiband_netcdf.py
+++ b/example_multiband/run_multiband_netcdf.py
@@ -36,12 +36,11 @@ def xyz_contains_data(z):
 
 
 for j in range(3):
+#for j in (0,):
     source = sources[j].load()
 
     i = 0
-    for z in range(0, 3):
+    for z in range(0, 4):
         x, y, z = xyz_contains_data(z)
         run(x, y, z, i, j)
         i += 1
-
-    # run(x-1, y, z, i, j)

--- a/example_multiband/run_multiband_netcdf.py
+++ b/example_multiband/run_multiband_netcdf.py
@@ -36,7 +36,6 @@ def xyz_contains_data(z):
 
 
 for j in range(3):
-#for j in (0,):
     source = sources[j].load()
 
     i = 0

--- a/mapshader/commands/build_raster_overviews.py
+++ b/mapshader/commands/build_raster_overviews.py
@@ -1,0 +1,37 @@
+import click
+import yaml
+
+from ..sources import MapSource
+
+
+@click.command(
+    no_args_is_help=True,
+    context_settings=dict(help_option_names=['-h', '--help']),
+    short_help='Build and cache raster overviews',
+    help=(
+        'Build and cache raster overviews.'
+    ),
+)
+@click.argument(
+    'config_yaml',
+    type=str,
+    required=True,
+)
+@click.option(
+    '--force',
+    'force',
+    is_flag=True,
+    help='Force recreation of overviews even if they already exist.',
+)
+def build_raster_overviews(config_yaml, force):
+    with open(config_yaml, 'r') as f:
+        content = f.read()
+        config_obj = yaml.safe_load(content)
+        source_objs = config_obj['sources']
+
+    for source_obj in source_objs:
+        if force:
+            source_obj["force_recreate_overviews"] = True
+
+        source = MapSource.from_obj(source_obj)
+        source = source.load()

--- a/mapshader/core.py
+++ b/mapshader/core.py
@@ -76,11 +76,14 @@ def create_agg(source: MapSource,
     agg_func = source.agg_func
     geometry_type = source.geometry_type
 
-    if z and z in source.overviews:
+    if isinstance(source.data, MultiFileNetCDF):
+        dataset = source.data.load_overview(z, source.band)
+        if dataset is None:
+            dataset = source.data.load_bounds(xmin, ymin, xmax, ymax, source.band,
+                                              source.transforms)
+    elif z and z in source.overviews:
         print(f'Using overview: {z}', file=sys.stdout)
         dataset = source.overviews[z]
-    elif isinstance(source.data, MultiFileNetCDF):
-        dataset = source.data.load_bounds(xmin, ymin, xmax, ymax, source.band, source.transforms)
     else:
         dataset = source.data
 

--- a/mapshader/core.py
+++ b/mapshader/core.py
@@ -80,7 +80,7 @@ def create_agg(source: MapSource,
         print(f'Using overview: {z}', file=sys.stdout)
         dataset = source.overviews[z]
     elif isinstance(source.data, MultiFileNetCDF):
-        dataset = source.data.load_bounds(xmin, ymin, xmax, ymax, source.band)
+        dataset = source.data.load_bounds(xmin, ymin, xmax, ymax, source.band, source.transforms)
     else:
         dataset = source.data
 

--- a/mapshader/io.py
+++ b/mapshader/io.py
@@ -7,8 +7,8 @@ import xarray as xr
 from mapshader.multifile import SharedMultiFile
 
 
-def load_raster(file_path, transforms, xmin=None, ymin=None,
-                xmax=None, ymax=None, chunks=None,
+def load_raster(file_path, transforms, force_recreate_overviews,
+                xmin=None, ymin=None, xmax=None, ymax=None, chunks=None,
                 layername='data'):
     """
     Load raster data.
@@ -52,7 +52,7 @@ def load_raster(file_path, transforms, xmin=None, ymin=None,
     elif file_path.endswith('.nc'):
 
         if '*' in file_path:
-            arr = SharedMultiFile.get(file_path, transforms)
+            arr = SharedMultiFile.get(file_path, transforms, force_recreate_overviews)
         else:
             # TODO: add chunk parameter to config
             arr = xr.open_dataset(file_path, chunks={'x': 512, 'y': 512})[layername]
@@ -64,7 +64,7 @@ def load_raster(file_path, transforms, xmin=None, ymin=None,
     return arr
 
 
-def load_vector(filepath: str, transforms):
+def load_vector(filepath: str, transforms, force_recreate_overviews):
     """
     Load vector data.
 

--- a/mapshader/io.py
+++ b/mapshader/io.py
@@ -7,7 +7,7 @@ import xarray as xr
 from mapshader.multifile import SharedMultiFile
 
 
-def load_raster(file_path, xmin=None, ymin=None,
+def load_raster(file_path, transforms, xmin=None, ymin=None,
                 xmax=None, ymax=None, chunks=None,
                 layername='data'):
     """
@@ -52,7 +52,7 @@ def load_raster(file_path, xmin=None, ymin=None,
     elif file_path.endswith('.nc'):
 
         if '*' in file_path:
-            arr = SharedMultiFile.get(file_path)
+            arr = SharedMultiFile.get(file_path, transforms)
         else:
             # TODO: add chunk parameter to config
             arr = xr.open_dataset(file_path, chunks={'x': 512, 'y': 512})[layername]
@@ -64,7 +64,7 @@ def load_raster(file_path, xmin=None, ymin=None,
     return arr
 
 
-def load_vector(filepath: str):
+def load_vector(filepath: str, transforms):
     """
     Load vector data.
 

--- a/mapshader/multifile.py
+++ b/mapshader/multifile.py
@@ -6,6 +6,8 @@ from shapely.geometry import Polygon
 from threading import Lock
 import xarray as xr
 
+from .transforms import get_transform_by_name
+
 
 class SharedMultiFile:
     """
@@ -20,11 +22,11 @@ class SharedMultiFile:
     _lookup = {}
 
     @classmethod
-    def get(cls, file_path):
+    def get(cls, file_path, transforms):
         with cls._lock:
             shared = cls._lookup.get(file_path, None)
             if not shared:
-                shared = MultiFileNetCDF(file_path)
+                shared = MultiFileNetCDF(file_path, transforms)
                 cls._lookup[file_path] = shared
         return shared
 
@@ -37,11 +39,12 @@ class MultiFileNetCDF:
     This is an interim solution until we replace the objects returned by
     load_raster() and load_vector() with a considered class hierarchy.
     """
-    def __init__(self, file_path):
+    def __init__(self, file_path, transforms):
         filenames = glob(file_path)
+        if not filenames:
+            raise RuntimeError(f"Unable to read any files from path {file_path}")
+
         self._lock = Lock()  # Limits reading of underlying data files to a single thread,
-        self._crs_file = None
-        self._bands = None
         xmins = []
         xmaxs = []
         ymins = []
@@ -51,22 +54,17 @@ class MultiFileNetCDF:
         # No thread locking required here as this is done by SharedMultiFile.get().
         for filename in filenames:
             with xr.open_dataset(filename, chunks=dict(y=512, x=512)) as ds:
-                if self._crs_file is None:
-                    self._crs_file = ds.rio.crs
-                    if not self._crs_file:
-                        # Fallback for reading spatial_ref written in strange way.
-                        self._crs_file = ds.spatial_ref.spatial_ref
-                        ds.rio.set_crs(self._crs_file)
-
-                    self._bands = list(ds.data_vars.keys())
-                # Should really check CRS is the same across all files.
+                # Can be any one of the DataArrays in the Dataset.
+                da = list(ds.values())[0]
+                da.rio.set_crs(self._get_crs(ds), inplace=True)
+                da = self._apply_transforms(da, transforms)
 
                 # x, y limits determined from coords.
                 # Could have been stored as attributes instead?
-                xmin = ds.x.min().item()
-                xmax = ds.x.max().item()
-                ymin = ds.y.min().item()
-                ymax = ds.y.max().item()
+                xmin = da.x.min().item()
+                xmax = da.x.max().item()
+                ymin = da.y.min().item()
+                ymax = da.y.max().item()
 
             xmins.append(xmin)
             xmaxs.append(xmax)
@@ -84,26 +82,34 @@ class MultiFileNetCDF:
             ymax=ymaxs,
         ))
 
-        # We don't yet have the CRS that the data needs to be in, so store
-        # loaded CRS and will reproject later.
-
-        if self._crs_file:
-            self._grid.set_crs(self._crs_file, inplace=True)
-
         # Actually it is slightly larger than this by half a pixel in each direction
         self._total_bounds = self._grid.total_bounds  # [xmin, ymin, xmax, ymax]
 
-        # Redirect calls like obj.rio.reproject() to obj.reproject().
-        # This is an unpleasant temporary solution.
-        self.rio = self
+    def _apply_transforms(self, da, transforms):
+        for trans in transforms:
+            transform_name = trans['name']
+            func = get_transform_by_name(transform_name)
+            args = trans.get('args', {})
 
-        self._crs_reproject = None
+            if 'overviews' in transform_name:
+                pass
+            else:
+                da = func(da, **args)
+
+        return da
+
+    def _get_crs(self, ds):
+        crs = ds.rio.crs
+        if not crs:
+            # Fallback for reading spatial_ref written in strange way.
+            crs = ds.spatial_ref.spatial_ref
+        return crs
 
     def full_extent(self):
         with self._lock:
             return self._total_bounds
 
-    def load_bounds(self, xmin, ymin, xmax, ymax, band):
+    def load_bounds(self, xmin, ymin, xmax, ymax, band, transforms):
         # Load data for required bounds from disk and return xr.DataArray containing it.
         # Not storing the loaded data in this class, relying on caller freeing the returned object
         # when it has finished with it.  May need to implement a cacheing strategy here?
@@ -111,15 +117,6 @@ class MultiFileNetCDF:
         # Need to test what happens with data that crosses longitude discontinuity.
 
         # Polygon of interest needs to be in files' CRS.
-        if self._crs_reproject:
-            with self._lock:
-                transformer = Transformer.from_crs(self._crs_reproject, self._crs_file)
-            xmin, ymin = transformer.transform(xmin, ymin)
-            xmax, ymax = transformer.transform(xmax, ymax)
-            if ymax < -179.999999 and self._crs_file == CRS("EPSG:4326"):
-                # Botch to deal with dodgy reprojection.
-                ymax = 180.0
-
         polygon = Polygon([(xmin, ymin), (xmax, ymin), (xmax, ymax), (xmin, ymax)])
         intersects = self._grid.intersects(polygon)  # pandas.Series of booleans.
         intersects = self._grid[intersects]  # geopandas.GeoDataFrame
@@ -130,42 +127,23 @@ class MultiFileNetCDF:
             return xr.DataArray()
 
         arrays = []
+        crs = None
         with self._lock:
             for i, filename in enumerate(intersects.filename):
                 with xr.open_dataset(filename, chunks=dict(y=512, x=512)) as ds:
-                    arr = ds[band]
+                    da = ds[band]
                     if i == 0:
-                        arr.rio.write_crs(self._crs_file, inplace=True)  # Only first needs CRS set.
-                    arrays.append(arr)
+                        crs = self._get_crs(ds)
+                        da.rio.set_crs(crs, inplace=True)
+                    arrays.append(da)
 
         merged = xr.merge(arrays)
-        # merged = merge_arrays(arrays)  # This gives mismatch between bounds and transform???
+        #merged = merge_arrays(arrays)  # This gives mismatch between bounds and transform???
 
         merged = merged[band]
-
-        if self._crs_reproject:
-            with self._lock:
-                merged = merged.rio.reproject(self._crs_reproject)
-
-        return merged
-
-    def reproject(self, proj_str):
-        if self._crs_reproject:
-            # Already reprojected so do not repeat.
-            return self
-
-        # Reproject the total bounds.
-        # Assuming x and y transforms are independent.
-        # This will not be necessary when required CRS is passed to constructor.
-        transformer = Transformer.from_crs(self._crs_file, proj_str)
-        xmin, ymin, xmax, ymax = self._total_bounds
-        xmin, ymin = transformer.transform(xmin, ymin)
-        xmax, ymax = transformer.transform(xmax, ymax)
+        merged.rio.set_crs(crs, inplace=True)
 
         with self._lock:
-            self._crs_reproject = proj_str
-            self._total_bounds = (xmin, ymin, xmax, ymax)
+            merged = self._apply_transforms(merged, transforms)
 
-        # Coordinates from individual netcdf files will be reprojected each time they are loaded.
-
-        return self
+        return merged

--- a/mapshader/multifile.py
+++ b/mapshader/multifile.py
@@ -1,13 +1,20 @@
+from affine import Affine
 import geopandas as gpd
 from glob import glob
-from pyproj import CRS, Transformer
+import numpy as np
+import os
+from rasterio.enums import Resampling
 import rioxarray  # noqa: F401
 from shapely.geometry import Polygon
 from threading import Lock
 import xarray as xr
 
+from .mercator import MercatorTileDefinition
 from .transforms import get_transform_by_name
 
+
+tile_def = MercatorTileDefinition(x_range=(-20037508.34, 20037508.34),
+                                  y_range=(-20037508.34, 20037508.34))
 
 class SharedMultiFile:
     """
@@ -22,11 +29,11 @@ class SharedMultiFile:
     _lookup = {}
 
     @classmethod
-    def get(cls, file_path, transforms):
+    def get(cls, file_path, transforms, force_recreate_overviews):
         with cls._lock:
             shared = cls._lookup.get(file_path, None)
             if not shared:
-                shared = MultiFileNetCDF(file_path, transforms)
+                shared = MultiFileNetCDF(file_path, transforms, force_recreate_overviews)
                 cls._lookup[file_path] = shared
         return shared
 
@@ -39,12 +46,16 @@ class MultiFileNetCDF:
     This is an interim solution until we replace the objects returned by
     load_raster() and load_vector() with a considered class hierarchy.
     """
-    def __init__(self, file_path, transforms):
+    def __init__(self, file_path, transforms, force_recreate_overviews):
+        self._file_path = file_path
+        self._base_dir = os.path.split(file_path)[0]
+
         filenames = glob(file_path)
         if not filenames:
             raise RuntimeError(f"Unable to read any files from path {file_path}")
 
         self._lock = Lock()  # Limits reading of underlying data files to a single thread,
+        self._bands = None
         xmins = []
         xmaxs = []
         ymins = []
@@ -54,6 +65,9 @@ class MultiFileNetCDF:
         # No thread locking required here as this is done by SharedMultiFile.get().
         for filename in filenames:
             with xr.open_dataset(filename, chunks=dict(y=512, x=512)) as ds:
+                if not self._bands:
+                    self._bands = list(ds.data_vars.keys())
+
                 # Can be any one of the DataArrays in the Dataset.
                 da = list(ds.values())[0]
                 da.rio.set_crs(self._get_crs(ds), inplace=True)
@@ -85,7 +99,17 @@ class MultiFileNetCDF:
         # Actually it is slightly larger than this by half a pixel in each direction
         self._total_bounds = self._grid.total_bounds  # [xmin, ymin, xmax, ymax]
 
+        # Overviews are dealt with separately as they need access to all the combined data.
+        # Assume create overviews for each band in the files.
+        raster_overviews = list(filter(lambda t: t["name"] == "build_raster_overviews", transforms))
+        if len(raster_overviews) > 1:
+            raise RuntimeError("build_raster_overviews may only appear once in transforms")
+        elif len(raster_overviews) > 0:
+            self._create_overviews(raster_overviews[0], transforms, force_recreate_overviews)
+
     def _apply_transforms(self, da, transforms):
+        # This may be called with either a single xr.DataArray that is a single band of a single
+        # NetCDF file, or with the merged output from a number of files called from load_bounds().
         for trans in transforms:
             transform_name = trans['name']
             func = get_transform_by_name(transform_name)
@@ -98,12 +122,117 @@ class MultiFileNetCDF:
 
         return da
 
+    def _create_overviews(self, raster_overviews, transforms, force_recreate_overviews=False):
+        print("_create_overviews", raster_overviews)
+
+        overview_directory = self._get_overview_directory()
+        if not os.path.isdir(overview_directory):
+            os.makedirs(overview_directory)
+
+        # Bounds of entire CRS.
+        xmin, ymin, xmax, ymax = tile_def.get_tile_meters(0, 0, 0)
+
+        for level, resolution in raster_overviews["args"]["levels"].items():
+            if not force_recreate_overviews:
+                # If overviews exist for all bands at this level can abort early.
+                if all([os.path.isfile(self._get_overview_filename(band, level))
+                        for band in self._bands]):
+                    print(f"Overviews exist for all bands at level {level} {self._bands}",
+                          flush=True)
+                    continue
+
+            # Overview shape, transform and CRS.
+            overview_shape = (resolution, resolution)
+
+            dx = (xmax - xmin) / resolution
+            dy = (ymax - ymin) / resolution
+            overview_transform = Affine.translation(xmin, ymin)*Affine.scale(dx, dy)
+
+            # CRS could be read from first loaded file (after transformation).
+            # But it is always EPSG:3857.
+            overview_crs = "EPSG:3857"
+
+            # Open a block of files at a time for writing to overview DataArray.
+            # Block size of one file initially.
+            # Each file needs transforms applied before it can be resampled/reprojected.
+            for band in self._bands:
+                overview_filename = self._get_overview_filename(band, level)
+                if not force_recreate_overviews and os.path.isfile(overview_filename):
+                    print(f"Overview already exists {overview_filename}", flush=True)
+                    continue
+
+                overview = None
+                for filename in self._grid.filename:
+                    with xr.open_dataset(filename, chunks=dict(y=512, x=512)) as ds:
+                        da = ds[band]
+                        crs = self._get_crs(ds)
+                        da.rio.set_crs(crs, inplace=True)
+
+                    da = self._apply_transforms(da, transforms)
+
+                    # Reproject to same grid as overview.
+                    da = da.rio.reproject(
+                        dst_crs=overview_crs,
+                        shape=overview_shape,
+                        transform=overview_transform,
+                        resampling=Resampling.average,
+                        nodata=np.nan)
+
+                    if overview is None:
+                        overview = da
+                    else:
+                        # Elementwise maximum taking into account nans.
+                        overview = xr.where(
+                            np.logical_and(np.isfinite(overview), ~(overview > da)),
+                            overview,
+                            da)
+
+                # Save overview as geotiff.
+                print(f"Writing overview {overview_filename}", flush=True)
+                overview.rio.to_raster(overview_filename)
+
+                if 1:
+                    import matplotlib.pyplot as plt
+                    plt.pcolor(overview)
+                    plt.show()
+
+#    values = {}
+#    overviews = {}
+#    for level, resolution in levels.items():
+#
+#        print(f'Generating Raster Overview level {level} at {resolution} pixel width',
+#              file=sys.stdout)
+#
+#        if resolution in values:
+#            overviews[int(level)] = values[resolution]
+#            continue
+#
+#        cvs = canvas_like(arr)
+#        height = height_implied_by_aspect_ratio(resolution, cvs.x_range, cvs.y_range)
+#        cvs.plot_height = height
+#        cvs.plot_width = resolution
+#        agg = (cvs.raster(arr, interpolate=interpolate)
+#                  .compute()
+#                  .chunk(512, 512)
+#                  .persist())
+#
+#        overviews[int(level)] = agg
+#        values[resolution] = agg
+#
+#    return overviews
+
     def _get_crs(self, ds):
         crs = ds.rio.crs
         if not crs:
             # Fallback for reading spatial_ref written in strange way.
             crs = ds.spatial_ref.spatial_ref
         return crs
+
+    def _get_overview_directory(self):
+        return os.path.join(self._base_dir, "overviews")
+
+    def _get_overview_filename(self, band, level):
+        return os.path.join(self._get_overview_directory(), f"{level}_{band}.tif")
 
     def full_extent(self):
         with self._lock:
@@ -138,7 +267,7 @@ class MultiFileNetCDF:
                     arrays.append(da)
 
         merged = xr.merge(arrays)
-        #merged = merge_arrays(arrays)  # This gives mismatch between bounds and transform???
+        # merged = merge_arrays(arrays)  # This gives mismatch between bounds and transform???
 
         merged = merged[band]
         merged.rio.set_crs(crs, inplace=True)

--- a/mapshader/multifile.py
+++ b/mapshader/multifile.py
@@ -125,10 +125,11 @@ class MultiFileNetCDF:
         return da
 
     def _create_single_band_overview(self, overview_shape, overview_transform, overview_crs, band,
-                                     overview_filename, transforms):
+                                     overview_filename, transforms, band_limits):
         # Open a block of files at a time for writing to overview DataArray.
         # Block size of one file initially.
         # Each file needs transforms applied before it can be resampled/reprojected.
+        calc_limits = band_limits[0] is None or band_limits[1] is None
         overview = None
         for filename in self._grid.filename:
             with xr.open_dataset(filename, chunks=dict(y=512, x=512)) as ds:
@@ -137,6 +138,13 @@ class MultiFileNetCDF:
                 da.rio.set_crs(crs, inplace=True)
 
             da = self._apply_transforms(da, transforms)
+
+            if calc_limits:
+                min_ = da.min().item()
+                max_ = da.max().item()
+                # Update limits in place.
+                band_limits[0] = min_ if band_limits[0] is None else min(band_limits[0], min_)
+                band_limits[1] = max_ if band_limits[1] is None else max(band_limits[1], max_)
 
             # Reproject to same grid as overview.
             da = da.rio.reproject(
@@ -160,6 +168,8 @@ class MultiFileNetCDF:
             if key in overview.attrs:
                 del overview.attrs[key]
 
+        overview.attrs["limits"] = band_limits
+
         # Save overview as geotiff.
         print(f"Writing overview {overview_filename}", flush=True)
         try:
@@ -180,6 +190,7 @@ class MultiFileNetCDF:
         levels_and_resolutions = raster_overviews["args"]["levels"]  # dict[int, int]
         tuple_keys = itertools.product(levels_and_resolutions.keys(), self._bands)
         self._overviews = dict.fromkeys(tuple_keys, None)
+        band_limits = dict.fromkeys(self._bands, [None, None])
 
         for level, resolution in levels_and_resolutions.items():
             if not force_recreate_overviews:
@@ -209,7 +220,7 @@ class MultiFileNetCDF:
 
                 self._create_single_band_overview(
                     overview_shape, overview_transform, overview_crs, band, overview_filename,
-                    transforms)
+                    transforms, band_limits[band])
 
     def _get_crs(self, ds):
         crs = ds.rio.crs

--- a/mapshader/sources.py
+++ b/mapshader/sources.py
@@ -10,6 +10,7 @@ from mapshader.colors import colors
 from mapshader.io import load_raster
 from mapshader.io import load_vector
 from mapshader.transforms import get_transform_by_name
+from .multifile import MultiFileNetCDF
 
 import spatialpandas
 
@@ -242,7 +243,7 @@ class MapSource:
                 print('Using Given Filepath unmodified: config{self.config_file}', file=sys.stdout)
                 data_path = self.filepath
 
-            data = self.load_func(data_path)
+            data = self.load_func(data_path, self.transforms)
         else:
             data = self.data
 
@@ -258,7 +259,8 @@ class MapSource:
         if self.is_loaded:
             return self
 
-        self._apply_transforms()
+        if not isinstance(self.data, MultiFileNetCDF):
+            self._apply_transforms()
 
         self.is_loaded = True
 

--- a/mapshader/transforms.py
+++ b/mapshader/transforms.py
@@ -290,8 +290,8 @@ def build_raster_overviews(arr, levels, interpolate='linear'):
                   .chunk(512, 512)
                   .persist())
 
-        overviews[int(level)] = None #agg
-        values[resolution] = None #agg
+        overviews[int(level)] = agg
+        values[resolution] = agg
 
     return overviews
 

--- a/mapshader/transforms.py
+++ b/mapshader/transforms.py
@@ -290,8 +290,8 @@ def build_raster_overviews(arr, levels, interpolate='linear'):
                   .chunk(512, 512)
                   .persist())
 
-        overviews[int(level)] = agg
-        values[resolution] = agg
+        overviews[int(level)] = None #agg
+        values[resolution] = None #agg
 
     return overviews
 

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup_args = dict(
         mapshader=mapshader.commands:main
 
         [mapshader.commands]
+        build_raster_overviews=mapshader.commands.build_raster_overviews:build_raster_overviews
         examples=mapshader.commands.examples:examples
         tif_to_netcdf=mapshader.commands.tif_to_netcdf:tif_to_netcdf
     ''',


### PR DESCRIPTION
This PR adds the caching of raster overviews for `MultiFileNetCDF` only. If yaml config file has a `build_raster_overviews`, section, the overviews are calculated and stored as GeoTIFF files in a new `overviews` directory within the directory containing the original NetCDF files. If the overview files are already present, it does not recreate them. When tiles are requested for a zoom level that is in an overview, the tile is generated from the overview rather than the original data, which should be much faster.

You can create the overviews using the command-line tool rather than the flask server:
```
mapshader build-raster-overviews <yaml file>
```
and can use the `--force` flag to force them to be recreated even if they already exist.

As part of this work, there is now better support for `transform`s for `MultiFileNetCDF`s. But usually it will be better to transform the original data as much as possible rather than having `mapshader` applying the transforms many times.