### PR TITLE
Support multiple GeoTIFF files

### DIFF
--- a/example_multiband/create_multiband_netcdf.py
+++ b/example_multiband/create_multiband_netcdf.py
@@ -35,6 +35,7 @@ for lat in range(lat_limits[0], lat_limits[1]):
 
         x = np.linspace(lon*scale + offset + dx/2, (lon + 1)*scale + offset - dx/2, nx)
         y = np.linspace(lat*scale + offset + dy/2, (lat + 1)*scale + offset - dy/2, ny)
+        y = y[::-1]
         filename = os.path.join("example_multiband", f"dummy_{lon}_{lat}.nc")
 
         red = rng.random(size=(ny, nx), dtype=np.float32)

--- a/mapshader/core.py
+++ b/mapshader/core.py
@@ -19,7 +19,7 @@ from xrspatial.utils import height_implied_by_aspect_ratio
 
 from mapshader.mercator import MercatorTileDefinition
 from mapshader.sources import MapSource
-from .multifile import MultiFileNetCDF
+from .multifile import MultiFileRaster
 
 import spatialpandas
 
@@ -76,8 +76,9 @@ def create_agg(source: MapSource,
     agg_func = source.agg_func
     geometry_type = source.geometry_type
 
-    if isinstance(source.data, MultiFileNetCDF):
+    if isinstance(source.data, MultiFileRaster):
         dataset = source.data.load_overview(z, source.band)
+        # Note this is really an xr.DataArray.
         if dataset is None:
             dataset = source.data.load_bounds(xmin, ymin, xmax, ymax, source.band,
                                               source.transforms)

--- a/mapshader/multifile.py
+++ b/mapshader/multifile.py
@@ -1,4 +1,5 @@
 from affine import Affine
+import dask
 import geopandas as gpd
 from glob import glob
 import itertools
@@ -52,13 +53,60 @@ class MultiFileRaster:
         self._file_path = file_path
         self._base_dir = os.path.split(file_path)[0]
 
+        self._lock = Lock()  # Limits reading of underlying data files to a single thread.
+        self._bands = None
+        self._overviews = None  # dict[tuple[int level, str band], xr.DataArray].  Loaded on demand.
+
+        # If cached grid file exists then read it, otherwise create grid and cache it.
+        self._grid = self._read_grid()
+        if self._grid is None:
+            self._grid = self._create_grid(file_path, transforms)
+
+            grid_directory = self._get_grid_directory()
+            if not os.path.isdir(grid_directory):
+                os.makedirs(grid_directory)
+            print(f"Writing grid {self._get_grid_filename()}", flush=True)
+            self._grid.to_file(self._get_grid_filename())
+        else:
+            # Need to know what bands are available.  Eventually this will be in yaml file so will
+            # not need to open a file here.
+            filename = glob(file_path)[0]
+            with xr.open_dataset(filename, chunks=dict(y=512, x=512)) as ds:
+                self._bands = [key for key in ds.data_vars.keys() if key != "spatial_ref"]
+
+        # Actually it is slightly larger than this by half a pixel in each direction
+        self._total_bounds = self._grid.total_bounds  # [xmin, ymin, xmax, ymax]
+
+        print("TOTAL_BOUNDS", self._total_bounds)
+
+        # Overviews are dealt with separately as they need access to all the combined data.
+        # Assume create overviews for each band in the files.
+        raster_overviews = list(filter(lambda t: t["name"] == "build_raster_overviews", transforms))
+        if len(raster_overviews) > 1:
+            raise RuntimeError("build_raster_overviews may only appear once in transforms")
+        elif len(raster_overviews) > 0:
+            self._create_overviews(raster_overviews[0], transforms, force_recreate_overviews)
+
+    def _apply_transforms(self, da, transforms):
+        # This may be called with either a single xr.DataArray that is a single band of a single
+        # NetCDF file, or with the merged output from a number of files called from load_bounds().
+        for trans in transforms:
+            transform_name = trans['name']
+            func = get_transform_by_name(transform_name)
+            args = trans.get('args', {})
+
+            if 'overviews' in transform_name:
+                pass
+            else:
+                da = func(da, **args)
+
+        return da
+
+    def _create_grid(self, file_path, transforms):
         filenames = glob(file_path)
         if not filenames:
             raise RuntimeError(f"Unable to read any files from path {file_path}")
 
-        self._lock = Lock()  # Limits reading of underlying data files to a single thread.
-        self._bands = None
-        self._overviews = None  # dict[tuple[int level, str band], xr.DataArray].  Loaded on demand.
         xmins = []
         xmaxs = []
         ymins = []
@@ -90,7 +138,7 @@ class MultiFileRaster:
             polygons.append(Polygon([(xmin, ymin), (xmax, ymin), (xmax, ymax), (xmin, ymax)]))
 
         # Create GeoDataFrame containing grid information.
-        self._grid = gpd.GeoDataFrame(dict(
+        grid = gpd.GeoDataFrame(dict(
             geometry=polygons,
             filename=filenames,
             xmin=xmins,
@@ -99,90 +147,7 @@ class MultiFileRaster:
             ymax=ymaxs,
         ))
 
-        # Actually it is slightly larger than this by half a pixel in each direction
-        self._total_bounds = self._grid.total_bounds  # [xmin, ymin, xmax, ymax]
-
-        print("TOTAL_BOUNDS", self._total_bounds)
-
-        # Overviews are dealt with separately as they need access to all the combined data.
-        # Assume create overviews for each band in the files.
-        raster_overviews = list(filter(lambda t: t["name"] == "build_raster_overviews", transforms))
-        if len(raster_overviews) > 1:
-            raise RuntimeError("build_raster_overviews may only appear once in transforms")
-        elif len(raster_overviews) > 0:
-            self._create_overviews(raster_overviews[0], transforms, force_recreate_overviews)
-
-    def _apply_transforms(self, da, transforms):
-        # This may be called with either a single xr.DataArray that is a single band of a single
-        # NetCDF file, or with the merged output from a number of files called from load_bounds().
-        for trans in transforms:
-            transform_name = trans['name']
-            func = get_transform_by_name(transform_name)
-            args = trans.get('args', {})
-
-            if 'overviews' in transform_name:
-                pass
-            else:
-                da = func(da, **args)
-
-        return da
-
-    def _create_single_band_overview(self, overview_shape, overview_transform, overview_crs, band,
-                                     overview_filename, transforms, band_limits):
-        # Open a block of files at a time for writing to overview DataArray.
-        # Block size of one file initially.
-        # Each file needs transforms applied before it can be resampled/reprojected.
-        calc_limits = band_limits[0] is None or band_limits[1] is None
-        overview = None
-        for filename in self._grid.filename:
-            with xr.open_dataset(filename, chunks=dict(y=512, x=512)) as ds:
-                da = ds[band]
-                crs = self._get_crs(ds)
-                da.rio.set_crs(crs, inplace=True)
-
-            da = self._apply_transforms(da, transforms)
-
-            if calc_limits:
-                min_ = da.min().item()
-                max_ = da.max().item()
-                # Update limits in place.
-                band_limits[0] = min_ if band_limits[0] is None else min(band_limits[0], min_)
-                band_limits[1] = max_ if band_limits[1] is None else max(band_limits[1], max_)
-
-            # Reproject to same grid as overview.
-            da = da.rio.reproject(
-                dst_crs=overview_crs,
-                shape=overview_shape,
-                transform=overview_transform,
-                resampling=Resampling.average,
-                nodata=np.nan)
-
-            if overview is None:
-                overview = da
-            else:
-                # Elementwise maximum taking into account nans.
-                overview = xr.where(
-                    np.logical_and(np.isfinite(overview), ~(overview > da)),
-                    overview,
-                    da)
-
-        # Remove attrs that can cause problem serializing xarrays.
-        for key in ["grid_mapping"]:
-            if key in overview.attrs:
-                del overview.attrs[key]
-
-        print("OVERVIEW LIMITS", band_limits)
-        overview.attrs["limits"] = band_limits
-        print(overview)
-
-        # Save overview as geotiff.
-        print(f"Writing overview {overview_filename}", flush=True)
-        try:
-            overview.rio.to_raster(overview_filename, tags=dict(hello="Ian"))
-        except:  # noqa: E722
-            if os.path.isfile(overview_filename):
-                os.remove(overview_filename)
-            raise
+        return grid
 
     def _create_overviews(self, raster_overviews, transforms, force_recreate_overviews=False):
         overview_directory = self._get_overview_directory()
@@ -227,6 +192,62 @@ class MultiFileRaster:
                     overview_shape, overview_transform, overview_crs, band, overview_filename,
                     transforms, band_limits[band])
 
+    def _create_single_band_overview(self, overview_shape, overview_transform, overview_crs, band,
+                                     overview_filename, transforms, band_limits):
+        # Open a block of files at a time for writing to overview DataArray.
+        # Block size of one file initially.
+        # Each file needs transforms applied before it can be resampled/reprojected.
+        calc_limits = band_limits[0] is None or band_limits[1] is None
+        overview = None
+        for filename in self._grid.filename:
+            with xr.open_dataset(filename, chunks=dict(y=512, x=512)) as ds:
+                da = ds[band]
+                crs = self._get_crs(ds)
+                da.rio.set_crs(crs, inplace=True)
+
+            da = self._apply_transforms(da, transforms)
+
+            if calc_limits:
+                min_ = da.min().item()
+                max_ = da.max().item()
+                # Update limits in place.
+                band_limits[0] = min_ if band_limits[0] is None else min(band_limits[0], min_)
+                band_limits[1] = max_ if band_limits[1] is None else max(band_limits[1], max_)
+
+            # Reproject to same grid as overview.
+            da = da.rio.reproject(
+                dst_crs=overview_crs,
+                shape=overview_shape,
+                transform=overview_transform,
+                # resampling=Resampling.average,  # Prefer this, but gives missing pixels.
+                resampling=Resampling.bilinear,
+                nodata=np.nan)
+
+            if overview is None:
+                overview = da
+            else:
+                # Elementwise maximum taking into account nans.
+                overview = xr.where(
+                    np.logical_and(np.isfinite(overview), ~(overview > da)),
+                    overview,
+                    da)
+
+        # Remove attrs that can cause problem serializing xarrays.
+        for key in ["grid_mapping"]:
+            if key in overview.attrs:
+                del overview.attrs[key]
+
+        overview.attrs["limits"] = band_limits
+
+        # Save overview as geotiff.
+        print(f"Writing overview {overview_filename}", flush=True)
+        try:
+            overview.rio.to_raster(overview_filename, tags=dict(hello="Ian"))
+        except:  # noqa: E722
+            if os.path.isfile(overview_filename):
+                os.remove(overview_filename)
+            raise
+
     def _get_crs(self, ds):
         crs = ds.rio.crs
         if not crs:
@@ -234,11 +255,29 @@ class MultiFileRaster:
             crs = ds.spatial_ref.spatial_ref
         return crs
 
+    def _get_grid_directory(self):
+        return os.path.join(self._base_dir, "grid")
+
+    def _get_grid_filename(self):
+        return os.path.join(self._get_grid_directory(), "mapshader_grid.shp")
+
     def _get_overview_directory(self):
         return os.path.join(self._base_dir, "overviews")
 
     def _get_overview_filename(self, level, band):
         return os.path.join(self._get_overview_directory(), f"{level}_{band}.tif")
+
+    def _read_grid(self):
+        grid_filename = self._get_grid_filename()
+
+        grid = None
+        if os.path.isfile(grid_filename):
+            try:
+                grid = gpd.read_file(grid_filename)
+                print(f"Read cached grid {grid_filename}")
+            except:  # noqa: E722
+                pass
+        return grid
 
     def full_extent(self):
         with self._lock:
@@ -272,14 +311,15 @@ class MultiFileRaster:
                         da.rio.set_crs(crs, inplace=True)
                     arrays.append(da)
 
-        merged = xr.merge(arrays)
-        # merged = merge_arrays(arrays)  # This gives mismatch between bounds and transform???
+        with dask.config.set({'array.slicing.split_large_chunks': True}):
+            merged = xr.merge(arrays)
+            # merged = merge_arrays(arrays)  # This gives mismatch between bounds and transform???
 
-        merged = merged[band]
-        merged.rio.set_crs(crs, inplace=True)
+            merged = merged[band]
+            merged.rio.set_crs(crs, inplace=True)
 
-        with self._lock:
-            merged = self._apply_transforms(merged, transforms)
+            with self._lock:
+                merged = self._apply_transforms(merged, transforms)
 
         return merged
 

--- a/mapshader/sources.py
+++ b/mapshader/sources.py
@@ -10,7 +10,7 @@ from mapshader.colors import colors
 from mapshader.io import load_raster
 from mapshader.io import load_vector
 from mapshader.transforms import get_transform_by_name
-from .multifile import MultiFileNetCDF
+from .multifile import MultiFileRaster
 
 import spatialpandas
 
@@ -263,7 +263,7 @@ class MapSource:
         if self.is_loaded:
             return self
 
-        if not isinstance(self.data, MultiFileNetCDF):
+        if not isinstance(self.data, MultiFileRaster):
             self._apply_transforms()
 
         self.is_loaded = True


### PR DESCRIPTION
This PR extends the support for sources that are multiple NetCDF files to also include multiple GeoTIFFs.

In addition, it also caches the `MultiFileRaster` grid (Geopandas dataframe) as it can take a substantial amount of time to recreate this for large numbers of file inputs (100-800 tested so far).

Also switched merging of multiple `xarray.DataArray`'s to use `rioxarray.merge.merge_arrays` rather than `xarray.merge` as it is a better and faster solution.