### PR TITLE
Support large GeoTIFF files with creation of overviews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ mapshader/_version.py
 
 # VS code stuff
 .vscode
+
+mapshader/.version
+examples/large_geotiff/

--- a/examples/large_geotiff.yaml
+++ b/examples/large_geotiff.yaml
@@ -1,0 +1,33 @@
+---
+sources:
+  - name: Large GeoTIFF
+    key: large-geotiff
+    text: Large GeoTIFF
+    description: large GeoTIFF
+    geometry_type: raster
+    shade_how: linear
+    cmap:
+      - black
+      - white
+    span:
+      - 0
+      - 1
+    raster_padding: 0
+    raster_interpolate: linear
+    xfield: geometry
+    yfield: geometry
+    filepath: examples/large_geotiff/large_geotiff*.tif
+    band: band_data
+    transforms:
+      - name: build_raster_overviews
+        args:
+          levels:
+            0: 256
+            1: 512
+            2: 1024
+            3: 2048
+            4: 4096
+            5: 8192
+            6: 16384
+    service_types:
+      - tile

--- a/mapshader/multifile.py
+++ b/mapshader/multifile.py
@@ -77,8 +77,6 @@ class MultiFileRaster:
         # Actually it is slightly larger than this by half a pixel in each direction
         self._total_bounds = self._grid.total_bounds  # [xmin, ymin, xmax, ymax]
 
-        print("TOTAL_BOUNDS", self._total_bounds)
-
         # Overviews are dealt with separately as they need access to all the combined data.
         # Assume create overviews for each band in the files.
         raster_overviews = list(filter(lambda t: t["name"] == "build_raster_overviews", transforms))
@@ -281,7 +279,11 @@ class MultiFileRaster:
                     da.rio.set_crs(crs, inplace=True)
                     arrays.append(da)
 
-        merged = merge_arrays(arrays)
+        if len(arrays) == 1:
+            merged = arrays[0]
+        else:
+            merged = merge_arrays(arrays)
+
         merged = merged.squeeze()
 
         with self._lock:

--- a/mapshader/tests/conftest.py
+++ b/mapshader/tests/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runlarge", action="store_true", default=False, help="run large tests"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "large: mark test as large")
+
+
+def pytest_collection_modifyitems(config, items):
+    if not config.getoption("--runlarge"):
+        skip_large = pytest.mark.skip(reason="use --runlarge option to run")
+        for item in items:
+            if "large" in item.keywords:
+                item.add_marker(skip_large)

--- a/mapshader/tests/test_large_geotiff.py
+++ b/mapshader/tests/test_large_geotiff.py
@@ -66,30 +66,24 @@ def test_large_geotiff_create_overviews():
 
 
 @pytest.mark.large
-def test_large_geotiff_read_overviews():
+@pytest.mark.parametrize("z, shape", [
+    [0, (55, 256)],
+    [1, (228, 512)],
+    [2, (457, 1024)],
+    [3, (911, 2048)],
+    [4, (1819, 4094)],
+    [5, (3636, 8186)],
+    [6, (7269, 16371)],
+])
+def test_large_geotiff_overview_files(z, shape):
     directory = os.path.join("examples", "large_geotiff", "overviews")
-    for overview in range(7):
-        filename = os.path.join(directory, f"{overview}_band_data.nc")
-        if not os.path.isfile(filename):
-            pytest.xfail("Overviews do not exist")
+    filename = os.path.join(directory, f"{z}_band_data.nc")
+    assert os.path.isfile(filename)
 
-    yaml_file = os.path.join("examples", "large_geotiff.yaml")
-    with open(yaml_file, 'r') as f:
-        content = f.read()
-        config_obj = yaml.safe_load(content)
-        source_obj = config_obj['sources'][0]
+    ds = xr.open_dataset(filename, chunks=dict(y=512, x=512))
+    da = ds["band_data"]
+    assert da.dtype == np.float32
+    assert da.shape == shape
 
-    source = MapSource.from_obj(source_obj)
-    source = source.load()
-
-    for z in range(8):
-        x = 2**(z-1) - 1
-        if x < 0:
-            x = 0
-        y = 0 if z < 2 else round(2**(z-1.65))
-
-        img = render_map(source, x=x, y=y, z=z, height=256, width=256)
-        one_color_component = img & 0xff
-        min_, max_ = one_color_component.min(), one_color_component.max()
-        assert max_ > 0
-        assert min_ < max_
+    assert da.min().compute().item() >= 0.0
+    assert da.max().compute().item() <= 1.0

--- a/mapshader/tests/test_large_geotiff.py
+++ b/mapshader/tests/test_large_geotiff.py
@@ -1,0 +1,95 @@
+import math
+import numpy as np
+import os
+import pytest
+import rioxarray
+import subprocess
+import xarray as xr
+import yaml
+
+from mapshader.sources import MapSource
+from mapshader.core import render_map
+
+
+def check_and_create_large_geotiff():
+    directory = os.path.join("examples", "large_geotiff")
+    filename = "large_geotiff.tif"
+    full_filename = os.path.join(directory, filename)
+
+    if os.path.isfile(full_filename):
+        # File already exists, so abort.
+        return
+
+    if not os.path.isdir(directory):
+        print(f"Creating directory {directory}")
+        os.makedirs(directory)
+
+    crs = "EPSG:3857"
+    x_limits = [-2e7, 2e7]
+    y_limits = [0.2e7, 1e7]
+
+    #nx = 10000  # 0.075 GB
+    nx = 115000  # 10 GB
+
+    dx = (x_limits[1] - x_limits[0]) / (nx-1)
+    ny = math.ceil((y_limits[1] - y_limits[0]) / dx) + 1
+
+    # Fix y_limits to work with ny
+    y_limits[1] = y_limits[0] + (ny-1)*dx
+
+    x = np.linspace(x_limits[0], x_limits[1], nx, dtype=np.float32)
+    y = np.linspace(y_limits[0], y_limits[1], ny, dtype=np.float32)
+
+    rng = np.random.default_rng(92741)
+    data = rng.random((ny, nx), dtype=np.float32)
+
+    dims = ["y", "x"]
+    ds = xr.Dataset(
+        data_vars=dict(band=(dims, data)),
+        coords=dict(y=y, x=x),
+        attrs=dict(description="large geotiff data", crs=crs),
+    )
+
+    ds.rio.to_raster(full_filename)
+
+    file_size_gb = os.path.getsize(full_filename) / (1024**3)
+    print(f"shape {ds['band'].shape}, file size {file_size_gb:.3f} GB")
+
+
+@pytest.mark.large
+def test_large_geotiff_create_overviews():
+    check_and_create_large_geotiff()
+
+    yaml_file = os.path.join("examples", "large_geotiff.yaml")
+    cmd = ["mapshader", "build-raster-overviews", yaml_file]
+    subprocess.run(cmd)
+
+
+@pytest.mark.large
+def test_large_geotiff_read_overviews():
+    directory = os.path.join("examples", "large_geotiff", "overviews")
+    for overview in range(7):
+        filename = os.path.join(directory, f"{overview}_band_data.nc")
+        if not os.path.isfile(filename):
+            pytest.xfail("Overviews do not exist")
+
+    yaml_file = os.path.join("examples", "large_geotiff.yaml")
+    with open(yaml_file, 'r') as f:
+        content = f.read()
+        config_obj = yaml.safe_load(content)
+        source_obj = config_obj['sources'][0]
+
+    source = MapSource.from_obj(source_obj)
+    source = source.load()
+
+    for z in range(8):
+        x = 2**(z-1) - 1
+        if x < 0:
+            x = 0
+        y = 0 if z < 2 else round(2**(z-1.65))
+
+        img = render_map(source, x=x, y=y, z=z, height=256, width=256)
+        one_color_component = img & 0xff
+        min_, max_ = one_color_component.min(), one_color_component.max()
+        assert max_ > 0
+        assert min_ < max_


### PR DESCRIPTION
This PR demonstrates support for large GeoTIFF files. 

There is a new test script `test_large_geotiff.py` that is labelled as `large` and is not run by `pytest` by default. To run it you need to use 
```
pytest mapshader/tests/test_large_geotiff.py --runlarge
```
This will create a 10 GB GeoTIFF file and overviews for zoom levels 0 to 6 inclusive. This can take ~30 minutes on a computer with 32 GB RAM, and 1.5 hours on one with 16 GB RAM.