### PR TITLE
Always use multi file opening code for VRTs

### DIFF
--- a/examples/large_vrt.yaml
+++ b/examples/large_vrt.yaml
@@ -16,7 +16,7 @@ sources:
     raster_interpolate: linear
     xfield: geometry
     yfield: geometry
-    filepath: examples/large_vrt/large_vrt*.vrt
+    filepath: examples/large_vrt/large_vrt.vrt
     band: band_data
     transforms:
       - name: build_raster_overviews

--- a/mapshader/io.py
+++ b/mapshader/io.py
@@ -40,13 +40,11 @@ def load_raster(file_path, transforms, force_recreate_overviews,
 
     arr = None
 
-    if '*' in file_path:
-        # Multiple files.
+    if '*' in file_path or file_extension == '.vrt':
         if file_extension in ['.nc', '.tif', '.vrt']:
             arr = SharedMultiFile.get(file_path, transforms, force_recreate_overviews)
 
     else:
-        # Single file.
         if file_extension == '.tif':
             arr = xr.open_rasterio(expanduser(file_path), chunks={'y': 512, 'x': 512})
 
@@ -59,7 +57,7 @@ def load_raster(file_path, transforms, force_recreate_overviews,
 
             arr.name = file_path
 
-        elif file_path.endswith('.nc'):
+        elif file_extension == '.nc':
             # TODO: add chunk parameter to config
             arr = xr.open_dataset(file_path, chunks={'x': 512, 'y': 512})[layername]
             arr['name'] = file_path


### PR DESCRIPTION
Even if there is no wildcard in the filepath, a VRT is always multiple files so use the `SharedMultiFile` opening code.