### PR TITLE
Support scanning directories for VRTs

### DIFF
--- a/mapshader/commands/serve.py
+++ b/mapshader/commands/serve.py
@@ -1,6 +1,7 @@
 import click
 
 from ..flask_app import create_app
+from ..scan import directory_to_config
 
 
 @click.command(
@@ -43,12 +44,20 @@ from ..flask_app import create_app
     default=False,
     help='Run server in debug mode',
 )
-def serve(config_yaml=None, host='0.0.0.0', port=5000, glob=None, debug=False):
+@click.option(
+    '--scan_directory',
+    type=click.Path(exists=True),
+)
+def serve(config_yaml=None, host='0.0.0.0', port=5000, glob=None, debug=False, scan_directory=None):
 
     from os import path
 
     if config_yaml:
         config_yaml = path.abspath(path.expanduser(config_yaml))
 
-    create_app(config_yaml, contains=glob).run(
+    sources = []
+    if scan_directory:
+        sources = directory_to_config(scan_directory)
+
+    create_app(config_yaml, contains=glob, sources=sources).run(
         host=host, port=port, debug=debug)

--- a/mapshader/flask_app.py
+++ b/mapshader/flask_app.py
@@ -164,7 +164,7 @@ def index_page(services):
     return template.render(services=services)
 
 
-def configure_app(app: Flask, user_source_filepath=None, contains=None):
+def configure_app(app: Flask, user_source_filepath=None, contains=None, sources=None):
 
     CORS(app)
 
@@ -177,7 +177,8 @@ def configure_app(app: Flask, user_source_filepath=None, contains=None):
     }
 
     services = []
-    for service in get_services(config_path=user_source_filepath, contains=contains):
+    for service in get_services(
+            config_path=user_source_filepath, contains=contains, sources=sources):
         services.append(service)
 
         view_func = view_func_creators[service.service_type]
@@ -205,9 +206,9 @@ def configure_app(app: Flask, user_source_filepath=None, contains=None):
     return app
 
 
-def create_app(user_source_filepath=None, contains=None):
+def create_app(user_source_filepath=None, contains=None, sources=None):
     app = Flask(__name__)
-    return configure_app(app, user_source_filepath, contains)
+    return configure_app(app, user_source_filepath, contains, sources)
 
 
 if __name__ == '__main__':

--- a/mapshader/scan.py
+++ b/mapshader/scan.py
@@ -1,0 +1,74 @@
+import fnmatch
+import os
+import re
+
+
+def _find_files(base_directory, pattern):
+    for root, _, files in os.walk(base_directory):
+        for file in files:
+            if fnmatch.fnmatch(file, pattern):
+                filename = os.path.join(root, file)
+                yield filename
+
+
+def _vrt_to_source_dicts(vrt_file, overview_levels):
+    source_dicts = []  # To return
+
+    name = os.path.splitext(os.path.basename(vrt_file))[0]
+    sanitised_name = name.replace(" ", "-")
+
+    source_dict = dict(
+        name=name,
+        text=name,
+        description=name,
+        key=sanitised_name,
+        filepath=vrt_file,
+        geometry_type="raster",
+        cmap=["white", "red"],
+        band="band_data",
+        service_types=["tile"],
+    )
+
+    transforms = []
+
+    # Check for existence of overviews, regardless of whether they are
+    # requested or not.
+    overview_directory = os.path.join(os.path.split(vrt_file)[0], "overviews")
+    if os.path.isdir(overview_directory):
+        pattern = re.compile(r"(\d+)_" + source_dict["band"] + ".tif")
+        for file in os.listdir(overview_directory):
+            m = pattern.match(file)
+            if m:
+                if overview_levels is None:
+                    overview_levels = []
+                overview_levels.append(int(m.group(1)))
+
+    if overview_levels:
+        overview_levels = sorted(list(set(overview_levels)))
+        levels = {level: 256*(2**level) for level in overview_levels}
+        transform = dict(
+            name="build_raster_overviews",
+            args=dict(levels=levels),
+        )
+        transforms.append(transform)
+
+    if transforms:
+        source_dict["transforms"] = transforms
+
+    source_dicts.append(source_dict)
+
+    return source_dicts
+
+
+def directory_to_config(directory, overview_levels=None):
+    # Scan directory for possible map sources.
+    print("directory_to_config", directory)
+
+    if not os.path.isdir(directory):
+        raise RuntimeError(f"Not a directory: '{directory}'")
+
+    source_dicts = []
+    for filename in _find_files(directory, "*.vrt"):
+        source_dicts += _vrt_to_source_dicts(filename, overview_levels)
+
+    return source_dicts

--- a/mapshader/services.py
+++ b/mapshader/services.py
@@ -285,7 +285,7 @@ def get_services(config_path=None, include_default=True, contains=None, sources=
 
     source_objs = None
 
-    if sources is not None:
+    if sources:
         source_objs = sources
 
     elif config_path is None:

--- a/mapshader/tests/test_large_geotiff.py
+++ b/mapshader/tests/test_large_geotiff.py
@@ -17,8 +17,12 @@ def test_large_geotiff_create_overviews():
     check_and_create_large_geotiff()
 
     yaml_file = os.path.join("examples", "large_geotiff.yaml")
-    cmd = ["mapshader", "build-raster-overviews", yaml_file]
-    subprocess.run(cmd)
+    cmd = ["mapshader", "build-raster-overviews", "--config_yaml", yaml_file]
+    subprocess.run(cmd, check=True)
+
+    for level in range(7):
+        filename = os.path.join("examples", "large_geotiff", "overviews", f"{level}_band_data.tif")
+        assert os.path.isfile(filename)
 
 
 @pytest.mark.large

--- a/mapshader/tests/test_large_vrt.py
+++ b/mapshader/tests/test_large_vrt.py
@@ -24,13 +24,13 @@ def create_tiles():
         tile_size = 8192
         cmd = ["gdal_retile.py", "-ps", str(tile_size), str(tile_size), "-targetDir",
                tile_directory, tiff_file]
-        subprocess.run(cmd)
+        subprocess.run(cmd, check=True)
 
         # Create VRT for tile set.
         tile_names = glob(os.path.join(tile_directory, "*.tif"))
         tile_names.sort()
         cmd = ["gdalbuildvrt", vrt_file] + tile_names
-        subprocess.run(cmd)
+        subprocess.run(cmd, check=True)
 
 
 @pytest.mark.large
@@ -43,8 +43,12 @@ def test_large_vrt_create_overviews():
     create_tiles()
 
     yaml_file = os.path.join("examples", "large_vrt.yaml")
-    cmd = ["mapshader", "build-raster-overviews", yaml_file]
-    subprocess.run(cmd)
+    cmd = ["mapshader", "build-raster-overviews", "--config_yaml", yaml_file]
+    subprocess.run(cmd, check=True)
+
+    for level in range(7):
+        filename = os.path.join("examples", "large_vrt", "overviews", f"{level}_band_data.tif")
+        assert os.path.isfile(filename)
 
 
 @pytest.mark.large


### PR DESCRIPTION
This PR add support for scanning directories to find VRTs without having to set up a YAML config file.

Typical usage is to first build raster overviews and then to serve the tiles. For test purposes, first create the test VRT using
```
pytest -v --runlarge mapshader/tests/test_large_vrt.py::test_large_vrt_create
```
and then scan for this VRT and build some overviews using
```
mapshader build-raster-overviews --scan_directory examples --overview_levels 0,1,2,3,4,5,6
```
Overview levels to build are specified as a single string without whitespace containing comma-separate integer overview zoom levels.

To serve the same VRTs with the pre-generated overviews:
```
mapshader serve --scan_directory examples
```

Note that it builds a source configuration for each VRT and makes some basic assumptions. In particular it does not know the data limits (the `span` config setting) and it purposely does not load all the data to determine the span as the data may be much larger than RAM. This is not really a problem for overviews, but when you zoom down levels finer than the overviews each tile will determine its own span which will probably not be what you want.

A future idea is to store metadata in the VRT to include the span limits.