### PR TITLE
Use relative url for psutils

### DIFF
--- a/mapshader/templates/psutils.html
+++ b/mapshader/templates/psutils.html
@@ -101,7 +101,7 @@
 </div>
 <script>
   const fetchAndPopulate = async () => {
-    const data = await fetch("http://localhost:5000/psutil");
+    const data = await fetch("/psutil");
     const log = await data.json();
 
     document.getElementById(


### PR DESCRIPTION
Fixes #116.

Manually tested using
```
mapshader serve --port 5001
```
which fails before this fix (psutils do not update in client web page) and works after.