### PR TITLE
Reduce test geotiff size from 10 GB to 1 GB

### DIFF
--- a/mapshader/tests/common.py
+++ b/mapshader/tests/common.py
@@ -22,7 +22,7 @@ def check_and_create_large_geotiff():
     x_limits = [-2e7, 2e7]
     y_limits = [0.2e7, 1e7]
 
-    nx = 115000  # 10 GB
+    nx = 36200  # 1 GB
 
     dx = (x_limits[1] - x_limits[0]) / (nx-1)
     ny = math.ceil((y_limits[1] - y_limits[0]) / dx) + 1

--- a/mapshader/tests/test_large_vrt.py
+++ b/mapshader/tests/test_large_vrt.py
@@ -21,7 +21,7 @@ def create_tiles():
 
         # Split single large GeoTIFF into multiple tiles.
         tiff_file = os.path.join("examples", "large_geotiff", "large_geotiff.tif")
-        tile_size = 8192
+        tile_size = 4096
         cmd = ["gdal_retile.py", "-ps", str(tile_size), str(tile_size), "-targetDir",
                tile_directory, tiff_file]
         subprocess.run(cmd)


### PR DESCRIPTION
This PR reduces the size of the GeoTIFF file that is used for testing purposes from 10 GB down to 1 GB. Also decreases the size of the test VRT tiles so that there are still a decent number of them.