### PR TITLE
Add synthetic people example

### DIFF
--- a/examples/census_synthetic_people.yaml
+++ b/examples/census_synthetic_people.yaml
@@ -23,6 +23,9 @@ sources:
     raster_interpolate: linear
     xfield: x
     yfield: y
-    filepath: makepath-prealpha-synthetic-people-2020/part.6.parquet
+    filepath: s3://makepath-synthetic-people-2022-alpha-webm-demo/part.6.parquet
     transforms:
       - name: load_in_memory
+    storage_options:
+        key: your_access_key_id
+        secret: your_secret_access_key

--- a/examples/census_synthetic_people.yaml
+++ b/examples/census_synthetic_people.yaml
@@ -12,6 +12,7 @@ sources:
       - tile
     cmap:
       - white
+    region_of_interest: -13898124.212, 2801774.864, -7445653.568, 6340332.344
     geometry_type: point
     shade_how: linear
     raster_interpolate: linear

--- a/examples/census_synthetic_people.yaml
+++ b/examples/census_synthetic_people.yaml
@@ -12,10 +12,17 @@ sources:
       - tile
     cmap:
       - white
-    region_of_interest: -13898124.212, 2801774.864, -7445653.568, 6340332.344
+    geometry_field: null
+    region_of_interest:
+      - -13898124.212
+      - 2801774.864
+      - -7445653.568
+      - 6340332.344
     geometry_type: point
     shade_how: linear
     raster_interpolate: linear
     xfield: x
     yfield: y
-    filepath: makepath-prealpha-synthetic-people-2020/*.parquet
+    filepath: makepath-prealpha-synthetic-people-2020/part.6.parquet
+    transforms:
+      - name: load_in_memory

--- a/examples/census_synthetic_people.yaml
+++ b/examples/census_synthetic_people.yaml
@@ -1,0 +1,23 @@
+---
+
+metadata:
+  version: 1
+
+sources:
+  - name: Census Blocks Synthetic People
+    key: census-synthetic-people
+    text: Census Blocks Synthetic People
+    description: Census Blocks Synthetic People
+    service_types:
+      - tile
+    span:
+      - 0
+      - 1
+    cmap:
+      - white
+    geometry_type: point
+    shade_how: linear
+    raster_interpolate: linear
+    xfield: x
+    yfield: y
+    filepath: synthetic-people/*.parquet

--- a/examples/census_synthetic_people.yaml
+++ b/examples/census_synthetic_people.yaml
@@ -10,9 +10,6 @@ sources:
     description: Census Blocks Synthetic People
     service_types:
       - tile
-    span:
-      - 0
-      - 1
     cmap:
       - white
     geometry_type: point

--- a/examples/census_synthetic_people.yaml
+++ b/examples/census_synthetic_people.yaml
@@ -20,4 +20,4 @@ sources:
     raster_interpolate: linear
     xfield: x
     yfield: y
-    filepath: synthetic-people/*.parquet
+    filepath: makepath-prealpha-synthetic-people-2020/*.parquet

--- a/mapshader/core.py
+++ b/mapshader/core.py
@@ -130,17 +130,21 @@ def point_aggregation(cvs, data, xfield, yfield, zfield, geometry_field, agg_fun
     """
 
     if zfield:
-        if geometry_field:
+        if xfield and yfield:
+            return cvs.points(data, xfield, yfield, getattr(ds, agg_func)(zfield))
+        elif geometry_field:
             return cvs.points(
                 data, agg=getattr(ds, agg_func)(zfield), geometry=geometry_field
             )
         else:
-            return cvs.points(data, xfield, yfield, getattr(ds, agg_func)(zfield))
+            raise ValueError('None of xfield, yfield, or geometry_field was provided')
     else:
-        if geometry_field:
+        if xfield and yfield:
+            return cvs.points(data, xfield, yfield)
+        elif geometry_field:
             return cvs.points(data, geometry=geometry_field)
         else:
-            return cvs.points(data, xfield, yfield)
+            raise ValueError('None of xfield, yfield, or geometry_field was provided')
 
 
 def line_aggregation(cvs, data, zfield, agg_func):

--- a/mapshader/io.py
+++ b/mapshader/io.py
@@ -9,7 +9,8 @@ import xarray as xr
 from mapshader.multifile import SharedMultiFile
 
 
-def load_raster(file_path, transforms, force_recreate_overviews, region_of_interest,
+def load_raster(file_path, transforms, force_recreate_overviews,
+                storage_options, geometry, region_of_interest,
                 xmin=None, ymin=None, xmax=None, ymax=None, chunks=None,
                 layername='data'):
     """
@@ -70,7 +71,14 @@ def load_raster(file_path, transforms, force_recreate_overviews, region_of_inter
     return arr
 
 
-def load_vector(filepath: str, transforms, force_recreate_overviews, region_of_interest):
+def load_vector(
+    filepath: str,
+    transforms,
+    force_recreate_overviews,
+    storage_options,
+    geometry,
+    region_of_interest,
+):
     """
     Load vector data.
 
@@ -87,6 +95,7 @@ def load_vector(filepath: str, transforms, force_recreate_overviews, region_of_i
 
     file_extension = splitext(filepath)[1]
 
+    # TODO: add storage_options to test from S3 dataset, public and private files
     if file_extension == '.parquet':
         if '*' in filepath:
             data = []

--- a/mapshader/io.py
+++ b/mapshader/io.py
@@ -1,7 +1,6 @@
 from os import listdir
 from os.path import expanduser, split, splitext
 
-import dask_geopandas as dask_gpd
 import geopandas as gpd
 import pandas as pd
 import numpy as np

--- a/mapshader/io.py
+++ b/mapshader/io.py
@@ -100,7 +100,5 @@ def load_vector(filepath: str, transforms, force_recreate_overviews):
         else:
             return pd.read_parquet(filepath)
 
-    elif file_extension == '.shp':
+    else:
         return gpd.read_file(filepath)
-
-    raise ValueError('Only supports shapfile and parquet data formats for vector data.')

--- a/mapshader/io.py
+++ b/mapshader/io.py
@@ -1,7 +1,5 @@
-from os import listdir
-from os.path import expanduser, split, splitext
+from os.path import expanduser, splitext
 
-import pandas as pd
 import numpy as np
 import xarray as xr
 import geopandas as gpd

--- a/mapshader/io.py
+++ b/mapshader/io.py
@@ -9,7 +9,7 @@ import xarray as xr
 from mapshader.multifile import SharedMultiFile
 
 
-def load_raster(file_path, transforms, force_recreate_overviews,
+def load_raster(file_path, transforms, force_recreate_overviews, region_of_interest,
                 xmin=None, ymin=None, xmax=None, ymax=None, chunks=None,
                 layername='data'):
     """
@@ -70,7 +70,7 @@ def load_raster(file_path, transforms, force_recreate_overviews,
     return arr
 
 
-def load_vector(filepath: str, transforms, force_recreate_overviews):
+def load_vector(filepath: str, transforms, force_recreate_overviews, region_of_interest):
     """
     Load vector data.
 
@@ -95,7 +95,17 @@ def load_vector(filepath: str, transforms, force_recreate_overviews):
             files = [f for f in listdir(base_dir) if 'parquet' in f]
             for f in files:
                 chunk_data = pd.read_parquet(base_dir + '/' + f)
+
+                if region_of_interest is not None:
+                    # limit data to be within the region of interest
+                    minx, miny, maxx, maxy = eval(region_of_interest)
+                    chunk_data = chunk_data[
+                        (chunk_data.x >= minx) & (chunk_data.x <= maxx)
+                        & (chunk_data.y >= miny) & (chunk_data.y <= maxy)
+                    ]
+
                 data.append(chunk_data)
+
             return pd.concat(data, ignore_index=True)
         else:
             return pd.read_parquet(filepath)

--- a/mapshader/sources.py
+++ b/mapshader/sources.py
@@ -127,6 +127,7 @@ class MapSource:
                  raster_padding=0,
                  service_types=None,
                  full_extent=None,
+                 region_of_interest=None,
                  default_extent=None,
                  default_height=256,
                  default_width=256,
@@ -204,6 +205,7 @@ class MapSource:
         self.geometry_field = geometry_field
         self.band = band
         self.force_recreate_overviews = force_recreate_overviews
+        self.region_of_interest = region_of_interest
 
         self.is_loaded = False
         self.data = data
@@ -248,7 +250,9 @@ class MapSource:
                 print('Using Given Filepath unmodified: config{self.config_file}', file=sys.stdout)
                 data_path = self.filepath
 
-            data = self.load_func(data_path, self.transforms, self.force_recreate_overviews)
+            data = self.load_func(
+                data_path, self.transforms, self.force_recreate_overviews, self.region_of_interest
+            )
         else:
             data = self.data
 

--- a/mapshader/sources.py
+++ b/mapshader/sources.py
@@ -244,6 +244,10 @@ class MapSource:
                 print('Zipfile Path', file=sys.stdout)
                 data_path = self.filepath
 
+            elif self.filepath.startswith('s3://'):
+                print('S3 Path', file=sys.stdout)
+                data_path = self.filepath
+
             elif not path.isabs(self.filepath):
                 print('Not Absolute', file=sys.stdout)
                 data_path = path.abspath(path.expanduser(self.filepath))

--- a/mapshader/sources.py
+++ b/mapshader/sources.py
@@ -4,6 +4,7 @@ import os
 from os import path
 import sys
 
+import pandas as pd
 import geopandas as gpd
 
 from mapshader.colors import colors
@@ -351,8 +352,16 @@ class VectorSource(MapSource):
     def full_extent(self):
         if isinstance(self.data, spatialpandas.GeoDataFrame):
             return self.data.to_geopandas()[self.geometry_field].total_bounds
-        else:
+        elif isinstance(self.data, gpd.GeoDataFrame):
             return self.data[self.geometry_field].total_bounds
+        elif isinstance(self.data, pd.DataFrame):
+            minx, miny, maxx, maxy = (
+                self.data[self.xfield].min(),
+                self.data[self.xfield].max(),
+                self.data[self.yfield].min(),
+                self.data[self.yfield].max()
+            )
+            return minx, miny, maxx, maxy
 
 
 # ----------------------------------------------------------------------------

--- a/mapshader/sources.py
+++ b/mapshader/sources.py
@@ -127,6 +127,7 @@ class MapSource:
                  raster_padding=0,
                  service_types=None,
                  full_extent=None,
+                 storage_options=None,
                  region_of_interest=None,
                  default_extent=None,
                  default_height=256,
@@ -198,6 +199,7 @@ class MapSource:
         self.extras = extras
         self.service_types = service_types
         self.transforms = transforms
+        self.storage_options = storage_options
         self.default_extent = default_extent
         self.default_width = default_width
         self.default_height = default_height
@@ -251,7 +253,12 @@ class MapSource:
                 data_path = self.filepath
 
             data = self.load_func(
-                data_path, self.transforms, self.force_recreate_overviews, self.region_of_interest
+                data_path,
+                self.transforms,
+                self.force_recreate_overviews,
+                self.storage_options,
+                self.geometry_field,
+                self.region_of_interest,
             )
         else:
             data = self.data

--- a/mapshader/transforms.py
+++ b/mapshader/transforms.py
@@ -452,4 +452,3 @@ def get_transform_by_name(name: str):
         The transform function name.
     """
     return _transforms[name]
-

--- a/mapshader/transforms.py
+++ b/mapshader/transforms.py
@@ -435,3 +435,13 @@ def get_transform_by_name(name: str):
         The transform function name.
     """
     return _transforms[name]
+
+
+def load_in_memory(gdf: gpd.GeoDataFrame):
+    """
+
+    Returns
+    -------
+
+    """
+

--- a/mapshader/transforms.py
+++ b/mapshader/transforms.py
@@ -408,6 +408,22 @@ def raster_to_categorical_points(arr, cats: dict, dim: str = 'data'):
     return df
 
 
+def load_in_memory(df):
+    """
+    Compute dask data frame.
+
+    Parameters
+    ----------
+    df: dask.dataframe or dask_geopandas.GeoDataFrame object
+
+    Returns
+    -------
+    computed_df: pandas.DataFrame or geopandas.GeoDataFrame object
+    """
+    df = df.compute()
+    return df
+
+
 _transforms = {
     'reproject_raster': reproject_raster,
     'reproject_vector': reproject_vector,
@@ -421,7 +437,8 @@ _transforms = {
     'add_xy_fields': add_xy_fields,
     'select_by_attributes': select_by_attributes,
     'polygon_to_line': polygon_to_line,
-    'raster_to_categorical_points': raster_to_categorical_points
+    'raster_to_categorical_points': raster_to_categorical_points,
+    'load_in_memory': load_in_memory,
 }
 
 
@@ -435,13 +452,4 @@ def get_transform_by_name(name: str):
         The transform function name.
     """
     return _transforms[name]
-
-
-def load_in_memory(gdf: gpd.GeoDataFrame):
-    """
-
-    Returns
-    -------
-
-    """
 

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,10 @@ setup_args = dict(
     ],
     install_requires=[
         'bokeh >=2.4.2',
-        'xarray-spatial >=0.3.1',
+        'xarray-spatial >=0.3.5',
         'datashader >=0.13.0',
         'geopandas >=0.10.2',
+        'dask-geopandas',
         'click >=8.0.3',
         'click_plugins >=1.1.1',
         'jinja2 >=3.0.3',


### PR DESCRIPTION
- support parquet file extension with single or multiple files 
- add config file for synthetic people example
 
In order to run the example, make sure the synthetic people data has been downloaded to your local machine, and the value of `filepath` in the config file is correct.
```
mapshader serve <path..>examples/census_synthetic_people.yaml
```